### PR TITLE
Made init and some file manager functions synchronous

### DIFF
--- a/Sources/SwiftCloudDrive/FileManager+Coordination.swift
+++ b/Sources/SwiftCloudDrive/FileManager+Coordination.swift
@@ -7,11 +7,10 @@
 
 import Foundation
 
-/// Wrapper for FileManager that offers async mehods
-/// These methods handle file coordination, which is quite useful
+/// Wrapper for FileManager with coordinated file access
 public extension FileManager {
             
-    func fileExists(coordinatingAccessAt fileURL: URL, presenter: NSFilePresenter? = nil) async throws -> (exists: Bool, isDirectory: Bool) {
+    func fileExists(coordinatingAccessAt fileURL: URL, presenter: NSFilePresenter? = nil) throws -> (exists: Bool, isDirectory: Bool) {
         var isDir: ObjCBool = false
         var exists: Bool = false
         try coordinate(readingItemAt: fileURL) { url in
@@ -20,25 +19,25 @@ public extension FileManager {
         return (exists, isDir.boolValue)
     }
     
-    func createDirectory(coordinatingAccessAt dirURL: URL, withIntermediateDirectories: Bool, presenter: NSFilePresenter? = nil) async throws {
+    func createDirectory(coordinatingAccessAt dirURL: URL, withIntermediateDirectories: Bool, presenter: NSFilePresenter? = nil) throws {
         try coordinate(writingItemAt: dirURL, options: .forMerging, presenter: presenter) { url in
             try createDirectory(at: url, withIntermediateDirectories: withIntermediateDirectories)
         }
     }
     
-    func removeItem(coordinatingAccessAt dirURL: URL, presenter: NSFilePresenter? = nil) async throws {
+    func removeItem(coordinatingAccessAt dirURL: URL, presenter: NSFilePresenter? = nil) throws {
         try coordinate(writingItemAt: dirURL, options: .forDeleting, presenter: presenter) { url in
             try removeItem(at: url)
         }
     }
     
-    func copyItem(coordinatingAccessFrom fromURL: URL, to toURL: URL, presenter: NSFilePresenter? = nil) async throws {
+    func copyItem(coordinatingAccessFrom fromURL: URL, to toURL: URL, presenter: NSFilePresenter? = nil) throws {
         try coordinate(readingItemAt: fromURL, readOptions: [], writingItemAt: toURL, writeOptions: .forReplacing, presenter: presenter) { readURL, writeURL in
             try copyItem(at: readURL, to: writeURL)
         }
     }
     
-    func contentsOfDirectory(coordinatingAccessAt dirURL: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions, presenter: NSFilePresenter? = nil) async throws -> [URL] {
+    func contentsOfDirectory(coordinatingAccessAt dirURL: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions, presenter: NSFilePresenter? = nil) throws -> [URL] {
         var contentsURLs: [URL] = []
         try coordinate(readingItemAt: dirURL, presenter: presenter) { url in
             contentsURLs = try contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
@@ -46,7 +45,7 @@ public extension FileManager {
         return contentsURLs
     }
     
-    func contentsOfFile(coordinatingAccessAt url: URL, presenter: NSFilePresenter? = nil) async throws -> Data {
+    func contentsOfFile(coordinatingAccessAt url: URL, presenter: NSFilePresenter? = nil) throws -> Data {
         var data: Data = .init()
         try coordinate(readingItemAt: url, presenter: presenter) { url in
             data = try Data(contentsOf: url)
@@ -54,19 +53,19 @@ public extension FileManager {
         return data
     }
     
-    func write(_ data: Data, coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil) async throws {
+    func write(_ data: Data, coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil) throws {
         try coordinate(writingItemAt: url, presenter: presenter) { url in
             try data.write(to: url)
         }
     }
     
-    func updateFile(coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil, in block: (URL) throws -> Void) async throws {
+    func updateFile(coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil, in block: (URL) throws -> Void) throws {
         try coordinate(writingItemAt: url, presenter: presenter) { url in
             try block(url)
         }
     }
 
-    func readFile(coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil, in block: (URL) throws -> Void) async throws {
+    func readFile(coordinatingAccessTo url: URL, presenter: NSFilePresenter? = nil, in block: (URL) throws -> Void) throws {
         try coordinate(readingItemAt: url, presenter: presenter) { url in
             try block(url)
         }

--- a/Sources/SwiftCloudDrive/MetadataMonitor.swift
+++ b/Sources/SwiftCloudDrive/MetadataMonitor.swift
@@ -23,10 +23,9 @@ class MetadataMonitor {
     deinit {
         NotificationCenter.default.removeObserver(self, name: .NSMetadataQueryDidFinishGathering, object: metadataQuery)
         NotificationCenter.default.removeObserver(self, name: .NSMetadataQueryDidUpdate, object: metadataQuery)
-        
-        nonisolated(unsafe) let query = metadataQuery
-        Task { @MainActor in
-            guard let query else { return }
+
+        guard let query = metadataQuery else { return }
+        query.operationQueue?.addOperation {
             query.disableUpdates()
             query.stop()
         }
@@ -46,9 +45,9 @@ class MetadataMonitor {
         NotificationCenter.default.addObserver(self, selector: #selector(handleMetadataNotification(_:)), name: .NSMetadataQueryDidFinishGathering, object: metadataQuery)
         NotificationCenter.default.addObserver(self, selector: #selector(handleMetadataNotification(_:)), name: .NSMetadataQueryDidUpdate, object: metadataQuery)
 
-        nonisolated(unsafe) let query = metadataQuery
-        Task { @MainActor in
-            query.start()
+        metadataQuery.operationQueue = OperationQueue.main
+        metadataQuery.operationQueue?.addOperation {
+            metadataQuery.start()
         }
     }
     

--- a/Tests/SwiftCloudDriveTests/CloudDriveTests.swift
+++ b/Tests/SwiftCloudDriveTests/CloudDriveTests.swift
@@ -2,61 +2,61 @@ import XCTest
 @testable import SwiftCloudDrive
 
 final class CloudDriveTests: XCTestCase {
-    
+
     var drive: CloudDrive!
     let dir1: RootRelativePath = .init(path: "Hi/There")
-    
+
     override func setUp() async throws {
         let tempDirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
         let url = URL(fileURLWithPath: tempDirPath, isDirectory: true)
-        drive = try await CloudDrive(storage: .localDirectory(rootURL: url))
+        drive = try CloudDrive(storage: .localDirectory(rootURL: url))
         try await super.setUp()
     }
-    
+
     override func tearDown() async throws {
         try await super.tearDown()
         try FileManager.default.removeItem(at: drive.rootDirectory)
     }
-    
-    func testDirectoryCreateAndRemove() async throws {
-        var exists = try await drive.directoryExists(at: dir1)
+
+    func testDirectoryCreateAndRemove() throws {
+        var exists = try drive.directoryExists(at: dir1)
         XCTAssertFalse(exists)
-        
-        try await drive.createDirectory(at: dir1)
-        exists = try await drive.directoryExists(at: dir1)
+
+        try drive.createDirectory(at: dir1)
+        exists = try drive.directoryExists(at: dir1)
         XCTAssertTrue(exists)
-        
+
         do {
-            try await drive.removeFile(at: dir1) // Should fail
+            try drive.removeFile(at: dir1) // Should fail
             XCTFail()
         } catch {
             XCTAssertTrue(true)
         }
-        
-        try await drive.removeDirectory(at: dir1)
+
+        try drive.removeDirectory(at: dir1)
     }
-    
-    func testFileReadWriteFile() async throws {
+
+    func testFileReadWriteFile() throws {
         let data = "Hi".data(using: .utf8)!
-        try await drive.writeFile(with: data, at: .root.appending("Direct"))
-        let readData = try await drive.readFile(at: .root.appending("Direct"))
+        try drive.writeFile(with: data, at: .root.appending("Direct"))
+        let readData = try drive.readFile(at: .root.appending("Direct"))
         XCTAssertEqual(data, readData)
-        try await drive.removeFile(at: .root.appending("Direct"))
+        try drive.removeFile(at: .root.appending("Direct"))
     }
-    
-    func testUploadAndDownload() async throws {
+
+    func testUploadAndDownload() throws {
         let data = "Hi".data(using: .utf8)!
         let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("CloudTempFile")
         try data.write(to: tempFile)
-        
-        try await drive.upload(from: tempFile, to: .root.appending("CloudTempFile"))
-        
+
+        try drive.upload(from: tempFile, to: .root.appending("CloudTempFile"))
+
         let tempFileDown = FileManager.default.temporaryDirectory.appendingPathComponent("tempdown")
         try? FileManager.default.removeItem(at: tempFileDown)
-        try await drive.download(from: .root.appending("CloudTempFile"), toURL: tempFileDown)
-        
+        try drive.download(from: .root.appending("CloudTempFile"), toURL: tempFileDown)
+
         let loadData = try Data(contentsOf: tempFileDown)
         XCTAssertEqual(loadData, data)
     }
-    
+
 }


### PR DESCRIPTION
My take on getting a synchronous init method. I fully respect if you don't use it. If/when you implement an async interface we will probably discard this too.